### PR TITLE
spawn: ignore custom prompt

### DIFF
--- a/testflows/uexpect/uexpect.py
+++ b/testflows/uexpect/uexpect.py
@@ -265,9 +265,15 @@ def _reader(out, queue, kill_event, encoding="utf-8", errors="backslashreplace")
 
 
 def spawn(command):
+    new_env = os.environ.copy()
+    if 'PS1' in new_env:
+        del new_env['PS1']
+    if 'PS2' in new_env:
+        del new_env['PS2']
     master, slave = pty.openpty()
     process = Popen(
         command,
+        env=new_env,
         preexec_fn=os.setsid,
         stdout=slave,
         close_fds=False,


### PR DESCRIPTION
Custom prompts may not match the default regexp
e.g. when they include color escape characters.
So it's better if we not set them when possible.